### PR TITLE
EPMDEDP-17134: fix: remove unused GitLab InsecureSkipVerify

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,39 @@ GitFusion can be deployed using the provided Helm chart:
 helm install gitfusion ./deploy-templates -n my-namespace
 ```
 
+### Connecting to a git server with a private or self-signed certificate
+
+GitFusion talks to git providers over HTTPS and **always verifies the server certificate**
+against the host's trust store (Go's default).
+
+To reach a provider served with a private or self-signed certificate (e.g. an internal
+GitLab), add its CA to the container's trust store — do **not** disable verification. On Linux,
+`/etc/ssl/certs` is the system trust-store directory that Go reads, so mounting the CA file
+there makes Go trust it alongside the public roots. Use the chart's `volumes`/`volumeMounts`,
+mounting the CA as a **single file via `subPath`** so the existing `ca-certificates.crt` bundle
+is preserved. For example, with the CA in a ConfigMap `gitlab-ca` (key `gitlab-ca.crt`):
+
+```yaml
+# values.yaml
+volumes:
+  - name: gitlab-ca
+    configMap:
+      name: gitlab-ca
+volumeMounts:
+  - name: gitlab-ca
+    mountPath: /etc/ssl/certs/gitlab-ca.crt   # subPath: do NOT mount over the whole dir
+    subPath: gitlab-ca.crt
+    readOnly: true
+```
+
+> Do not mount a volume over the whole `/etc/ssl/certs` directory — that shadows the bundled
+> public roots and breaks TLS to public providers (GitHub, Bitbucket). Always use `subPath`.
+
+Alternatively, on **Linux** set `SSL_CERT_FILE` (a single PEM bundle) or `SSL_CERT_DIR` to a
+mounted CA path. These apply to every provider and keep verification enabled. (Go does not
+honour `SSL_CERT_FILE`/`SSL_CERT_DIR` on macOS — relevant only for local runs, not the
+container.)
+
 ## API Documentation
 
 GitFusion exposes a RESTful API defined using OpenAPI specification. The API includes endpoints for:

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -90,16 +90,17 @@ autoscaling:
   # targetMemoryUtilizationPercentage: 80
 
 # Additional volumes on the output Deployment definition.
+# Trust a private/self-signed git CA (see README): mount the CA as a single file via subPath.
 volumes: []
-# - name: foo
-#   secret:
-#     secretName: mysecret
-#     optional: false
+# - name: gitlab-ca
+#   configMap:
+#     name: gitlab-ca
 
 # Additional volumeMounts on the output Deployment definition.
 volumeMounts: []
-# - name: foo
-#   mountPath: "/etc/foo"
+# - name: gitlab-ca
+#   mountPath: /etc/ssl/certs/gitlab-ca.crt
+#   subPath: gitlab-ca.crt
 #   readOnly: true
 
 # -- https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector

--- a/internal/services/gitlab/gitlab.go
+++ b/internal/services/gitlab/gitlab.go
@@ -2,17 +2,14 @@ package gitlab
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	gitlab "gitlab.com/gitlab-org/api/client-go"
@@ -22,44 +19,9 @@ import (
 	"github.com/KubeRocketCI/gitfusion/internal/services/krci"
 )
 
-// insecureSkipVerify reports whether TLS certificate verification is disabled for GitLab
-// requests. It is controlled by GITFUSION_GITLAB_INSECURE_SKIP_VERIFY and defaults to false,
-// keeping certificate verification on. Set it to "true" to connect to a GitLab instance that
-// serves a self-signed certificate.
-var insecureSkipVerify = os.Getenv("GITFUSION_GITLAB_INSECURE_SKIP_VERIFY") == "true"
-
-var insecureWarnOnce sync.Once
-
 // newGitlabClient builds a go-gitlab client for the given git server settings.
 func newGitlabClient(settings krci.GitServerSettings) (*gitlab.Client, error) {
-	opts := []gitlab.ClientOptionFunc{gitlab.WithBaseURL(settings.Url)}
-
-	if insecureSkipVerify {
-		opts = append(opts, gitlab.WithHTTPClient(newGitlabHTTPClient(0)))
-	}
-
-	return gitlab.NewClient(settings.Token, opts...)
-}
-
-// newGitlabHTTPClient builds an http.Client for GitLab requests. A timeout of 0 leaves the
-// client without a deadline (used for the go-gitlab client, which makes long paginated
-// calls); a non-zero timeout bounds one-shot calls such as the job-trace fetch.
-func newGitlabHTTPClient(timeout time.Duration) *http.Client {
-	c := &http.Client{Timeout: timeout}
-
-	if insecureSkipVerify {
-		insecureWarnOnce.Do(func() {
-			slog.Warn("GITFUSION_GITLAB_INSECURE_SKIP_VERIFY is enabled — TLS certificate verification disabled")
-		})
-
-		// InsecureSkipVerify is enabled only on explicit opt-in via
-		// GITFUSION_GITLAB_INSECURE_SKIP_VERIFY=true (self-signed GitLab certificates).
-		c.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
-		}
-	}
-
-	return c
+	return gitlab.NewClient(settings.Token, gitlab.WithBaseURL(settings.Url))
 }
 
 // maxTraceBytes caps the job trace read to prevent OOM on runaway logs (4 MiB).
@@ -459,7 +421,9 @@ func (g *GitlabProvider) GetJobTrace(
 
 	req.Header.Set("PRIVATE-TOKEN", settings.Token)
 
-	resp, err := newGitlabHTTPClient(traceRequestTimeout).Do(req)
+	httpClient := &http.Client{Timeout: traceRequestTimeout}
+
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return "", false, fmt.Errorf("failed to fetch job trace for %s job %d: %w", project, jobID, err)
 	}


### PR DESCRIPTION
Snyk SAST flagged InsecureSkipVerify: true (CWE-295) in the GitLab client. It was an off-by-default, env-gated path that was never used: gitfusion already verifies TLS against Go's default system trust store. Private or self-signed CAs are trusted by mounting the CA into the container trust store (the platform-standard pattern, as the codebase-operator does), so removing the flag keeps certificate verification always on with no functional change.

Document the CA-mount approach in the README and chart values, and inline the now-trivial HTTP client helper. Validated end-to-end against a self-signed GitLab: repository, branch, organization and pipeline discovery succeed with the CA mounted and fail closed with an x509 "unknown authority" error without it.
